### PR TITLE
Fixed ajax request URL

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -44,7 +44,7 @@ $('#form-cep').submit(function(e)  {
   responseBox.text('Buscando...')
 
   $.ajax({
-    url: `http://fastcep.appspot.com/${formattedInput}`,
+    url: `https://fastcep.appspot.com/${formattedInput}`,
     method: 'GET'
   }).done(data => {
     responseBox.text(JSON.stringify(data, null, 2))


### PR DESCRIPTION
Ajax requests must be over HTTPS when you load a page over HTTPS.

So, the current demonstration at the [website](https://quickcep.github.io/frontend/) is throwing:
![image](https://user-images.githubusercontent.com/18057391/47611625-d708a000-da47-11e8-8a9b-97bf0a9f9669.png)

I think changing `http://fastcep.appspot.com/${formattedInput}` just to `https://fastcep.appspot.com/${formattedInput}` is going to fix the Mixed Content error.